### PR TITLE
[Feat] Docs: Swagger(OpenAPI 3) 어노테이션 추가하여 API 명세

### DIFF
--- a/src/main/java/com/example/job_weather_back/controller/LikedEmployment/LikedEmploymentController.java
+++ b/src/main/java/com/example/job_weather_back/controller/LikedEmployment/LikedEmploymentController.java
@@ -5,6 +5,14 @@ import com.example.job_weather_back.entity.User;
 import com.example.job_weather_back.repository.LikedEmploymentRepository;
 import com.example.job_weather_back.dto.LikedEmploymentDTO;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.http.HttpStatus;
@@ -18,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Tag(name = "Liked Employment API", description = "찜한 채용공고 관리 API")
 @CrossOrigin
 @Slf4j
 @RestController
@@ -33,6 +42,15 @@ public class LikedEmploymentController {
         return userInfo;
     }
 
+    @Operation(summary = "채용공고 찜하기 (북마크 추가)", description = "현재 로그인된 사용자가 특정 채용공고를 찜 목록에 추가합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "찜하기 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(implementation = LikedEmployment.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 유효하지 않은 ID 형식)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요", content = @Content),
+            @ApiResponse(responseCode = "409", description = "이미 찜한 공고", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @PostMapping
     public ResponseEntity<?> addBookmark(@RequestBody LikedEmploymentDTO dto, HttpSession session) {
         User userInfo = getLoggedInUser(session);
@@ -71,7 +89,15 @@ public class LikedEmploymentController {
         }
     }
 
-
+    @Operation(summary = "찜한 채용공고 삭제 (북마크 제거)", description = "현재 로그인된 사용자의 찜 목록에서 특정 채용공고를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"message\": \"즐겨찾기가 삭제되었습니다.\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 유효하지 않은 ID 형식)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요", content = @Content),
+            @ApiResponse(responseCode = "404", description = "삭제할 찜한 공고를 찾을 수 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @DeleteMapping("/{saraminJobId}")
     public ResponseEntity<?> removeBookmark(@PathVariable String saraminJobId, HttpSession session) {
         User userInfo = getLoggedInUser(session);
@@ -106,9 +132,16 @@ public class LikedEmploymentController {
         }
     }
 
-
+    @Operation(summary = "특정 사용자의 찜한 채용공고 ID 목록 조회", description = "경로 변수로 전달된 userSn에 해당하는 사용자가 찜한 채용공고의 ID(empNum) 목록을 반환합니다. (자신의 정보만 조회 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = Integer.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요", content = @Content),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (다른 사용자의 정보 조회 시도)", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류", content = @Content)
+    })
     @GetMapping("/user/{userSn}")
-public ResponseEntity<?> getUserBookmarks(@PathVariable int userSn, HttpSession session) {
+    public ResponseEntity<?> getUserBookmarks(@PathVariable int userSn, HttpSession session) {
     User userInfo = getLoggedInUser(session);
 
     if (userInfo == null || userInfo.getUserSn() != userSn) {

--- a/src/main/java/com/example/job_weather_back/controller/NewContentsController.java
+++ b/src/main/java/com/example/job_weather_back/controller/NewContentsController.java
@@ -9,8 +9,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.util.List;
 
+@Tag(name = "New Contents API", description = "새로운 소식(뉴스/채용 정보 통합) 조회 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/new-contents")
@@ -19,12 +28,27 @@ public class NewContentsController {
     private final NewContentsRepository newContentsRepository;
 
     // 전체 소식 조회 (뉴스 + 채용)
+    @Operation(summary = "모든 새로운 소식 조회", description = "시스템에 저장된 모든 새로운 소식(뉴스 및 채용 정보 통합) 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = NewContents.class)))
+            // 필요시 500 에러 응답 등 추가
+    })
     @GetMapping
     public List<NewContents> getAll() {
         return newContentsRepository.findAll();
     }
 
     // 특정 타입(news/job)만 조회
+    @Operation(summary = "특정 타입의 새로운 소식 조회", description = "경로 변수로 전달된 타입('news' 또는 'job')에 해당하는 새로운 소식 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = NewContents.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 타입 파라미터 (예: 'news' 또는 'job'이 아닌 경우)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 타입의 소식 없음 (빈 리스트 반환 가능)", content = @Content)
+    })
     @GetMapping("/{type}")
     public List<NewContents> getByType(@PathVariable String type) {
         return newContentsRepository.findByType(type);

--- a/src/main/java/com/example/job_weather_back/controller/NewsController.java
+++ b/src/main/java/com/example/job_weather_back/controller/NewsController.java
@@ -31,6 +31,17 @@ import java.util.stream.Collectors;
 import java.util.Locale;
 import java.util.Optional;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+// import io.swagger.v3.oas.annotations.parameters.RequestBody; // Spring의 RequestBody와 이름이 같으므로, 사용할 때 정규화된 이름 사용
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name = "News API", description = "뉴스 조회, 검색 및 찜하기 관련 API")
 @RestController
 @RequestMapping("/news")
 @CrossOrigin(origins = "http://localhost:5173", allowedHeaders = "*", allowCredentials = "true")
@@ -57,6 +68,14 @@ public class NewsController {
     );
 
     // 프론트의 뉴스 검색 응답
+    @Operation(summary = "뉴스 목록 조회 또는 검색", description = "검색어(search) 유무에 따라 전체 최신 뉴스 목록 또는 검색 결과를 반환합니다. 검색어가 없으면 모든 뉴스를 최신순으로 반환합니다.")
+    @ApiResponses(value = {
+            // 응답 스키마를 Map 또는 Object로 변경
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                                 schema = @Schema(type = "object", example = "{\"items\": [{\"newsSn\":1, ...}], \"total\": 1}"))),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
     @GetMapping
     public ResponseEntity<?> getNews(@RequestParam(required = false) String search) {
         try {
@@ -205,6 +224,12 @@ public class NewsController {
     }
 
     // 찜한 뉴스 목록 조회
+    @Operation(summary = "찜한 뉴스 ID 목록 조회", description = "현재 로그인된 사용자가 찜한 뉴스의 ID 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(type = "array", implementation = Integer.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+    })
     @GetMapping("/liked")
     public ResponseEntity<?> getLikedNews(@SessionAttribute("user_info") User user) {
         List<LikedNews> likedNewsList = likedNewsRepository.findByUserUserSn(user.getUserSn());
@@ -216,6 +241,12 @@ public class NewsController {
     }
 
     // 뉴스 찜하기/찜하기 취소
+    @Operation(summary = "뉴스 찜하기/찜 취소 (토글)", description = "특정 뉴스를 찜하거나 찜 목록에서 제거합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "찜하기/찜 취소 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 뉴스 ID 누락 또는 존재하지 않는 뉴스)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+    })
     @PostMapping("/like")
     public ResponseEntity<?> toggleLike(
             @RequestBody Map<String, Integer> body,

--- a/src/main/java/com/example/job_weather_back/controller/NotificationController.java
+++ b/src/main/java/com/example/job_weather_back/controller/NotificationController.java
@@ -10,9 +10,18 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.util.List;
 import java.util.Optional;
 
+@Tag(name = "Notification API", description = "알림 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/notifications")
@@ -23,18 +32,38 @@ public class NotificationController {
     private final UserMatchService userMatchService;
 
     // 모든 알림 조회
+    @Operation(summary = "모든 알림 조회 (관리자용)", description = "시스템에 저장된 모든 사용자의 알림 목록을 반환합니다. (주로 관리자 기능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = Notification.class)))
+    })
     @GetMapping
     public List<Notification> getAll() {
         return notificationRepository.findAll();
     }
 
     // 특정 사용자 알림만 조회
+    @Operation(summary = "특정 사용자 알림 조회", description = "경로 변수로 전달된 특정 사용자의 모든 알림 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = Notification.class))),
+            @ApiResponse(responseCode = "404", description = "해당 사용자의 알림 없음 (빈 리스트 반환 가능)", content = @Content)
+    })
     @GetMapping("/user/{userSn}")
     public List<Notification> getByUser(@PathVariable Integer userSn) {
         return notificationRepository.findAllByUser_UserSn(userSn);
     }
 
-
+    @Operation(summary = "현재 사용자 맞춤 알림 목록 조회 (매칭 기반)", description = "현재 로그인된 사용자의 관심사에 맞는 다른 사용자 매칭 결과를 알림 형태로 반환합니다. (세션 기반)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = NotificationDto.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음 (테스트용 임시 로직)", content = @Content)
+    })
     @PostMapping("/user-matching")
     public List<NotificationDto> getNotificationList(HttpSession session) {
 //        User user = (User) session.getAttribute("user_info");

--- a/src/main/java/com/example/job_weather_back/controller/RecommendationController.java
+++ b/src/main/java/com/example/job_weather_back/controller/RecommendationController.java
@@ -1,9 +1,19 @@
-package com.example.job_weather_back.controller; // 또는 com.example.job_weather_back.recommendation.controller;
+package com.example.job_weather_back.controller; // 실제 컨트롤러 패키지 경로
 
 import com.example.job_weather_back.dto.MainPageRecommendationsDto;
 import com.example.job_weather_back.service.RecommendationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpSession; // HttpSession import 추가
+
+import org.slf4j.Logger; // Logger import 추가
+import org.slf4j.LoggerFactory; // LoggerFactory import 추가
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,56 +22,80 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
+// 만약 이 컨트롤러가 RecommendationController라면 클래스명도 변경하는 것이 좋습니다.
+// 여기서는 파일명은 WeatherController.java로 되어있지만, 내용은 RecommendationController에 가깝습니다.
+// @Tag(name = "Recommendation API", description = "메인 페이지 추천 관련 API")
+@Tag(name = "Main Page API", description = "메인 페이지 추천 및 날씨 관련 API") // 태그명 수정
 @RestController
-@RequestMapping("/api/main/recommendations")
+@RequestMapping("/api/main/recommendations") // 이 컨트롤러는 추천 관련이므로 경로 유지
 @CrossOrigin(origins = "http://localhost:5173", allowedHeaders = "*", allowCredentials = "true")
-public class RecommendationController {
+public class RecommendationController { // 클래스명도 RecommendationController로 변경하는 것이 좋음
 
     private static final Logger log = LoggerFactory.getLogger(RecommendationController.class);
     private final RecommendationService recommendationService;
 
-    @Autowired // 생성자가 하나만 있을 경우 Spring 5부터는 생략 가능
+    @Autowired
     public RecommendationController(RecommendationService recommendationService) {
         this.recommendationService = recommendationService;
     }
 
+    @Operation(summary = "메인 페이지 추천 콘텐츠 조회", description = "로그인 상태에 따라 맞춤형 또는 일반 추천 뉴스/채용공고 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = { @Content(mediaType = "application/json",
+                         schema = @Schema(implementation = MainPageRecommendationsDto.class)) }),
+            @ApiResponse(responseCode = "204", description = "추천할 콘텐츠 없음", content = @Content)
+    })
     @GetMapping
-    public ResponseEntity<MainPageRecommendationsDto> getMainPageRecommendations() {
+    public ResponseEntity<MainPageRecommendationsDto> getMainPageRecommendations(HttpSession session) { // HttpSession 파라미터 추가
         log.info("메인 페이지 추천 정보 요청 수신.");
         try {
-            // 메인 페이지 접근 시마다 일반 사용자 추천 목록 업데이트
-            // 뉴스 수집은 RecommendationService 내부의 스케줄러 또는 이 메소드에서 호출된
-            // fetchAndSaveNewsFromNaverApi가 담당 (현재는 스케줄러 제거 상태)
-            // fetchAndSaveNewsFromNaverApi를 여기서 호출하면 매번 API를 호출하므로 주의
-            // recommendationService.fetchAndSaveNewsFromNaverApi(); // 필요시 주석 해제 (매우 주의)
-            recommendationService.populateGeneralRecommendations();
-            log.info("일반 사용자 추천 목록 업데이트 완료.");
-
+            // 서비스 메소드에서 필요시 뉴스 수집 및 추천 생성을 먼저 수행하도록 변경했으므로,
+            // 컨트롤러에서는 getRecommendationsForMainPage만 호출합니다.
+            // recommendationService.populateGeneralRecommendations(); // 이전에 여기서 호출하던 로직은 서비스 내부 또는 스케줄러로 이동
         } catch (Exception e) {
-            log.error("추천 콘텐츠 사전 작업 중 오류 발생", e);
-            // 이 경우, 그냥 기존에 저장된 추천을 보여주거나 에러를 반환할 수 있습니다.
-            // 여기서는 일단 getRecommendationsForMainPage()를 계속 진행합니다.
+            log.error("추천 콘텐츠 사전 작업 중 오류 발생 (컨트롤러)", e);
+            // 서비스에서 오류를 처리하고, 여기서는 최종 조회만 시도
         }
 
-        MainPageRecommendationsDto recommendations = recommendationService.getRecommendationsForMainPage();
-        if (recommendations.getNews() == null || recommendations.getNews().isEmpty() /* && (recommendations.getJobs() == null || recommendations.getJobs().isEmpty()) */) {
-            // 추천할 내용이 전혀 없을 경우 204 No Content
+        MainPageRecommendationsDto recommendations = recommendationService.getRecommendationsForMainPage(session); // session 객체 전달
+        if (recommendations == null || (recommendations.getNews() == null || recommendations.getNews().isEmpty()) /* && (recommendations.getJobs() == null || recommendations.getJobs().isEmpty()) */) {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(recommendations);
     }
 
-    // 스케줄러 대신 수동으로 뉴스 수집 및 추천 생성을 트리거하기 위한 엔드포인트 (개발/테스트용)
+    @Operation(summary = "일반 사용자용 추천 콘텐츠 수동 생성", description = "스케줄러와 별개로 현재 시점의 뉴스 수집 및 일반 사용자용 추천 콘텐츠를 강제로 생성하고 DB에 저장합니다. (주로 테스트용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "콘텐츠 생성 작업 시작/완료", content = @Content(mediaType = "text/plain")),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 발생", content = @Content)
+    })
     @PostMapping("/populate-general")
     public ResponseEntity<String> populateGeneralRecommendationsManually() {
         try {
             log.info("수동으로 뉴스 수집 및 일반 사용자 추천 콘텐츠 생성 시작...");
-            recommendationService.fetchAndSaveNewsFromNaverApi(); // 뉴스 먼저 수집
-            recommendationService.populateGeneralRecommendations(); // 그 다음 추천 생성
+            recommendationService.fetchAndSaveNewsFromNaverApi();
+            recommendationService.populateGeneralRecommendations();
             return ResponseEntity.ok("뉴스 수집 및 일반 사용자 추천 콘텐츠 생성을 완료했습니다.");
         } catch (Exception e) {
             log.error("수동 추천 콘텐츠 생성 중 오류 발생", e);
             return ResponseEntity.status(500).body("추천 콘텐츠 생성 중 오류 발생: " + e.getMessage());
         }
     }
+
+    // 만약 특정 사용자의 추천을 수동으로 생성하는 API가 필요하다면 추가
+    /*
+    @Operation(summary = "특정 사용자 맞춤 추천 콘텐츠 수동 생성", description = "특정 사용자의 맞춤 추천 콘텐츠를 강제로 생성합니다. (테스트용)")
+    @PostMapping("/populate-user/{userSn}")
+    public ResponseEntity<String> populateUserSpecificRecommendationsManually(@PathVariable Integer userSn) {
+        try {
+            log.info("{} 사용자의 맞춤 추천 콘텐츠 수동 생성 시작...", userSn);
+            recommendationService.populateUserSpecificRecommendations(userSn);
+            return ResponseEntity.ok(userSn + " 사용자의 맞춤 추천 콘텐츠 생성을 완료했습니다.");
+        } catch (Exception e) {
+            log.error("{} 사용자 맞춤 추천 생성 중 오류 발생", userSn, e);
+            return ResponseEntity.status(500).body("맞춤 추천 생성 중 오류: " + e.getMessage());
+        }
+    }
+    */
 }

--- a/src/main/java/com/example/job_weather_back/controller/UserController.java
+++ b/src/main/java/com/example/job_weather_back/controller/UserController.java
@@ -8,9 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 import com.example.job_weather_back.dto.KakaoDto;
 import com.example.job_weather_back.dto.LogInDto;
@@ -23,18 +20,23 @@ import com.example.job_weather_back.repository.UserRepository;
 import com.example.job_weather_back.service.KakaoService;
 import com.example.job_weather_back.service.NaverService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+//import io.swagger.v3.oas.annotations.parameters.RequestBody;//
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "User API", description = "사용자 인증, 관리 및 소셜 로그인 관련 API")
 @CrossOrigin
 @Slf4j
 @RestController
@@ -51,6 +53,12 @@ public class UserController {
   @Autowired
   LikedNewsRepository likedNewsRepository;
 
+  @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터", content = @Content)
+    })
   @Transactional
   @PostMapping("/signup")
   public User signupPost(@RequestBody SignUpDto dto) {
@@ -65,6 +73,13 @@ public class UserController {
     return userRepository.save(user);
   }
 
+
+  @Operation(summary = "로그인", description = "이메일과 비밀번호를 사용하여 로그인하고 세션을 생성합니다.")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (이메일 또는 비밀번호 불일치)", content = @Content)
+  })
   @Transactional
   @PostMapping("/login")
   public ResponseEntity<User> loginPost(@RequestBody LogInDto dto, HttpSession session) {
@@ -76,11 +91,22 @@ public class UserController {
     return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
   }
 
+  @Operation(summary = "닉네임 중복 확인", description = "제공된 닉네임의 사용 가능 여부를 확인합니다. (true: 사용 가능, false: 이미 사용 중)")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "확인 결과 반환",
+                         content = @Content(mediaType = "application/json", schema = @Schema(type = "boolean")))
+  })
   @GetMapping("/nickname") // 닉네임 존재 여부 찾기
   public boolean checkNickname(@RequestParam String nickname) {
     return !userRepository.existsByUserNickname(nickname);
   }
 
+  @Operation(summary = "비밀번호 재설정", description = "이메일 확인 후 새 비밀번호로 변경합니다. (현재 로직은 이메일만으로 사용자를 찾아 비밀번호를 변경합니다. 실제 구현 시 추가 인증 필요)")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 재설정 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
+            @ApiResponse(responseCode = "404", description = "해당 이메일의 사용자 없음", content = @Content)
+  })
   @Transactional
   @PostMapping("/reset-password")
   public ResponseEntity<User> resetPwPost(@RequestBody LogInDto dto) {
@@ -91,6 +117,11 @@ public class UserController {
     return ResponseEntity.ok(user);
   }
 
+  @Operation(summary = "이메일 가입 여부 확인", description = "제공된 이메일이 이미 가입되어 있는지 확인합니다. (true: 이미 가입됨, false: 가입되지 않음)")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "확인 결과 반환",
+                         content = @Content(mediaType = "application/json", schema = @Schema(type = "boolean")))
+  })
   @GetMapping("/email") // 가입된 이메일 찾기
   public boolean checkemail(@RequestParam String email) {
     return userRepository.existsByEmail(email);
@@ -103,6 +134,11 @@ public class UserController {
   private String redirect_uri;
 
   // kakao 로그인 url
+  @Operation(summary = "카카오 로그인 URL 요청", description = "카카오 인증을 위한 인가 코드 요청 URL을 반환합니다. 클라이언트는 이 URL로 리다이렉트해야 합니다.")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "카카오 로그인 URL 문자열",
+                         content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "https://kauth.kakao.com/oauth/authorize?...")))
+  })
   @GetMapping("/kakaologin")
   public String getKakaoLoginUrl() {
 
@@ -113,6 +149,10 @@ public class UserController {
   }
 
   // kako사용자 정보 반환, 로그인 회원가입
+  @Operation(summary = "카카오 로그인 콜백 처리 (GET)", description = "카카오로부터 인가 코드를 받아 로그인/회원가입 처리 후 메인 페이지로 리다이렉트합니다. (API 명세 테스트 어려움)")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "메인 페이지(http://localhost:5173/)로 리다이렉트")
+  })
   @GetMapping("/social-login")
   public void kakaoCallback(@RequestParam String code, HttpServletResponse response, HttpSession session)
       throws IOException {
@@ -151,6 +191,11 @@ public class UserController {
   }
 
   // 회원 탈퇴
+  @Operation(summary = "회원 탈퇴", description = "현재 로그인된 사용자의 정보를 삭제하고 세션을 무효화합니다. 소셜 로그인 사용자의 경우 연결 끊기를 시도합니다.")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "탈퇴 성공", content = @Content(mediaType = "text/plain")),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+  })
   @Transactional
   @DeleteMapping("/delete")
   public ResponseEntity<?> deleteUser(HttpSession session) {
@@ -183,6 +228,11 @@ public class UserController {
     return ResponseEntity.ok("탈퇴 완료");
   }
 
+
+  @Operation(summary = "로그아웃", description = "현재 로그인된 사용자의 세션을 무효화하고, 소셜 로그인 사용자의 경우 로그아웃 처리 후 메인 페이지로 리다이렉트합니다.")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "메인 페이지 또는 소셜 로그아웃 페이지로 리다이렉트")
+  })
   @PostMapping("/logout")
   public void logout(HttpSession session, HttpServletResponse response) throws IOException {
     String accessToken = (String) session.getAttribute("access_token");
@@ -217,6 +267,11 @@ public class UserController {
   private String naver_client_secret;
 
   // naver 로그인 url
+  @Operation(summary = "네이버 로그인 URL 요청", description = "네이버 인증을 위한 인가 코드 요청 URL을 반환합니다. 클라이언트는 이 URL로 리다이렉트해야 합니다.")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "네이버 로그인 URL 문자열",
+                         content = @Content(mediaType = "text/plain", schema = @Schema(type = "string", example = "https://nid.naver.com/oauth2.0/authorize?...")))
+  })
   @GetMapping("/naverlogin")
   public String getNaverLoginUrl() {
 
@@ -228,6 +283,10 @@ public class UserController {
   }
 
   // naverlogin
+  @Operation(summary = "네이버 로그인 콜백 처리 (GET)", description = "네이버로부터 인가 코드를 받아 로그인/회원가입 처리 후 메인 페이지로 리다이렉트합니다. (API 명세 테스트 어려움)")
+  @ApiResponses(value = {
+            @ApiResponse(responseCode = "302", description = "메인 페이지(http://localhost:5173/)로 리다이렉트")
+  })
   @GetMapping("/naver-login")
   public void naverCallback(@RequestParam String code, HttpServletResponse response, HttpSession session)
       throws IOException {

--- a/src/main/java/com/example/job_weather_back/controller/mypage/CustomController.java
+++ b/src/main/java/com/example/job_weather_back/controller/mypage/CustomController.java
@@ -25,6 +25,14 @@ import com.example.job_weather_back.repository.CustomPositionRepository;
 import com.example.job_weather_back.repository.CustomizationRepository;
 import com.example.job_weather_back.service.CustomizationService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,7 +42,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
-
+@Tag(name = "User Customization API (Mypage)", description = "마이페이지 - 사용자 맞춤 설정(관심사) 관련 API")
 @CrossOrigin
 @RestController
 public class CustomController {
@@ -45,6 +53,15 @@ public class CustomController {
     @Autowired CustomizationService customizationService;
 
     // 저장된 맞춤설정 불러오기
+    @Operation(summary = "저장된 맞춤설정 조회", description = "현재 로그인된 사용자의 저장된 맞춤설정(기업유형, 포지션, 지역 ID)을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "object", example = "{\"companyType\": 1, \"position\": 2, \"location\": 3}"))),
+            @ApiResponse(responseCode = "200", description = "저장된 맞춤설정 없음 (빈 객체 반환)",
+                         content = @Content(mediaType = "application/json", schema = @Schema(type = "object", example = "{}"))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요", content = @Content)
+    })
     @GetMapping("/mypage/custom")
     public ResponseEntity<?> printCustom(HttpSession session) {
         User userInfo = (User) session.getAttribute("user_info");
@@ -72,6 +89,14 @@ public class CustomController {
     }
 
     // 맞춤설정의 옵션들 조회
+    @Operation(summary = "맞춤설정 옵션 목록 조회", description = "특정 카테고리(position, companyType, location)에 대한 전체 옵션 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", implementation = Object.class, // 실제 타입은 item에 따라 다름
+                                          example = "[{\"positionId\":1, \"positionName\":\"백엔드\"}, ...] 또는 [{\"typeId\":1, \"typeName\":\"대기업SI\"}, ...]"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 카테고리 이름", content = @Content)
+    })
     @GetMapping("/mypage/custom/{item}")
     public ResponseEntity<?> getMethodName(@PathVariable String item) {
         List<?> list;
@@ -90,6 +115,13 @@ public class CustomController {
     }
 
     // 새로 설정된 맞춤설정 저장
+    @Operation(summary = "맞춤설정 저장/수정", description = "현재 로그인된 사용자의 맞춤설정(기업유형, 포지션, 지역)을 저장하거나 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "저장/수정 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"success\": true, \"message\": \"맞춤설정 저장 완료\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 또는 저장 실패", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요", content = @Content)
+    })
     @PostMapping("/mypage/custom")
     public ResponseEntity<?> saveCustom(@RequestBody CustomDTO dto, HttpSession session) {
         try{

--- a/src/main/java/com/example/job_weather_back/controller/mypage/LikedController.java
+++ b/src/main/java/com/example/job_weather_back/controller/mypage/LikedController.java
@@ -18,6 +18,15 @@ import com.example.job_weather_back.repository.LikedEmploymentRepository;
 import com.example.job_weather_back.repository.LikedNewsRepository;
 import com.example.job_weather_back.service.LikedEmpService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 
@@ -27,6 +36,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
 
+@Tag(name = "Liked Content API (Mypage)", description = "마이페이지 - 사용자가 찜한 뉴스 및 채용공고 관리 API")
 @CrossOrigin
 @RestController
 public class LikedController {
@@ -35,6 +45,13 @@ public class LikedController {
     @Autowired LikedEmpService likedEmpService;
 
     // 스크랩한 뉴스 제목 + url 반환
+    @Operation(summary = "찜한 뉴스 목록 조회", description = "현재 로그인된 사용자가 찜한 뉴스 목록을 반환합니다. (날짜 시간순 정렬)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", example = "[{\"id\": 101, \"title\": \"뉴스 제목\", \"url\": \"http://...\", \"description\": \"...\", \"date\": \"2025-05-22T10:30:00\"}]"))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+    })
     @GetMapping("/mypage/liked/news")
     public ResponseEntity<?> getLikedNews(HttpSession session) {
         User user = (User) session.getAttribute("user_info");
@@ -62,6 +79,13 @@ public class LikedController {
     }
 
     // 스크랩한 채용공고 반환
+    @Operation(summary = "찜한 채용공고 목록 조회", description = "현재 로그인된 사용자가 찜한 채용공고 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json",
+                         schema = @Schema(type = "array", example = "[{\"empNum\": 201, \"companyName\": \"회사명\", ...}]"))), // 실제 반환 DTO로 변경
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+    })
     @GetMapping("/mypage/liked/emp")
     public ResponseEntity<?> getLikedEmp(HttpSession session) {
         User user = (User) session.getAttribute("user_info");
@@ -84,6 +108,15 @@ public class LikedController {
     
     
     // 스크랩 취소
+    // 추가: DeleteMapping으로 바꾸는 게 좋다고 합니다. (RESTful 원칙...)
+    @Operation(summary = "찜한 항목 삭제 (뉴스 또는 채용공고)", description = "현재 로그인된 사용자의 찜 목록에서 특정 뉴스 또는 채용공고를 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"success\": true, \"message\": \"스크랩 취소 완료\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (item 종류 또는 itemId 오류)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "삭제할 찜한 항목을 찾을 수 없음", content = @Content)
+    })
     @Transactional
     @PostMapping("/mypage/unliked/{item}/{itemId}")
     public ResponseEntity<?> deletLiked(

--- a/src/main/java/com/example/job_weather_back/controller/mypage/MypageController.java
+++ b/src/main/java/com/example/job_weather_back/controller/mypage/MypageController.java
@@ -5,14 +5,30 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.web.bind.annotation.GetMapping;
 
-
+@Tag(name = "Mypage API", description = "마이페이지 관련 기본 API (예: 로그인 상태 확인)")
 @CrossOrigin
 @RestController
 public class MypageController {
+
+    @Operation(summary = "로그인 상태 확인", description = "현재 사용자의 로그인 여부를 확인합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "로그인 확인됨",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"message\": \"로그인 확인\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"message\": \"로그인이 필요합니다.\"}")))
+    })
     @GetMapping("/mypage/check")
     public ResponseEntity<?> getMethodName(HttpSession session) {
         if(session.getAttribute("user_info") == null) {

--- a/src/main/java/com/example/job_weather_back/controller/mypage/ProfileController.java
+++ b/src/main/java/com/example/job_weather_back/controller/mypage/ProfileController.java
@@ -11,6 +11,14 @@ import com.example.job_weather_back.dto.ProfileDTO;
 import com.example.job_weather_back.entity.User;
 import com.example.job_weather_back.repository.UserRepository;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 import jakarta.servlet.http.HttpSession;
 
 import org.springframework.web.bind.annotation.CrossOrigin;
@@ -19,12 +27,20 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
 
+@Tag(name = "User Profile API (Mypage)", description = "마이페이지 - 사용자 프로필 정보 조회 및 수정, 비밀번호 확인 API")
 @CrossOrigin
 @RestController
 public class ProfileController {
     @Autowired UserRepository userRepository;
 
     // 회원정보 조회
+    @Operation(summary = "회원정보 조회", description = "현재 로그인된 사용자의 프로필 정보를 반환합니다. (회원정보 수정을 위한 이전 데이터 조회용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(implementation = User.class))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자 정보를 찾을 수 없음", content = @Content)
+    })
     @GetMapping("/mypage/profile")
     public User printProfile(HttpSession session) {
         User user = (User) session.getAttribute("user_info");
@@ -37,6 +53,14 @@ public class ProfileController {
     }
     
     //회원정보 수정
+    @Operation(summary = "회원정보 수정", description = "현재 로그인된 사용자의 프로필 정보를 전달받은 내용으로 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"message\": \"Update successfully\"}"))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (예: 중복된 닉네임)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
+    })
     @PostMapping("/mypage/profile")
     public ResponseEntity<String> updateProfile(
         @RequestBody ProfileDTO profileDTO,
@@ -67,6 +91,14 @@ public class ProfileController {
     }
     
     //비밀번호 확인
+    @Operation(summary = "비밀번호 확인", description = "현재 로그인된 사용자의 비밀번호가 입력된 비밀번호와 일치하는지 확인합니다. (주로 회원 탈퇴 전 확인용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "비밀번호 일치",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"success\": true}"))),
+            @ApiResponse(responseCode = "400", description = "비밀번호 불일치 또는 잘못된 요청",
+                         content = @Content(mediaType = "application/json", schema = @Schema(example = "{\"success\": false, \"message\": \"비밀번호 불일치\"}"))),
+            @ApiResponse(responseCode = "401", description = "로그인 필요 (인증되지 않음)", content = @Content)
+    })
     @PostMapping("/mypage/profile/checkPw")
     public ResponseEntity<?> checkPw(
         @RequestBody Map<String,String> body,

--- a/src/main/java/com/example/job_weather_back/weather/controller/WeatherController.java
+++ b/src/main/java/com/example/job_weather_back/weather/controller/WeatherController.java
@@ -2,6 +2,15 @@ package com.example.job_weather_back.weather.controller; // 패키지명 weather
 
 import com.example.job_weather_back.weather.dto.WeatherResponseDto;
 import com.example.job_weather_back.weather.service.WeatherService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag; // Tag import
+
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,6 +24,7 @@ import org.springframework.web.bind.annotation.CrossOrigin; // CORS 사용 시
 import java.time.LocalDate;
 import java.util.Optional;
 
+@Tag(name = "Weather API", description = "'오늘의 채용 날씨' 관련 API")
 @RestController
 @RequestMapping("/api/weather")
 @CrossOrigin(origins = "http://localhost:5173", allowedHeaders = "*", allowCredentials = "true") // 프론트엔드 주소에 맞게
@@ -30,6 +40,13 @@ public class WeatherController {
      * (수동 트리거용) 오늘의 채용 날씨 정보를 생성하고 DB에 저장합니다.
      * @return 생성된 날씨 정보 또는 에러 메시지
      */
+    @Operation(summary = "오늘의 채용 날씨 정보 수동 생성", description = "스케줄러와 별개로 현재 시점의 날씨 정보를 강제로 생성하고 DB에 저장합니다. (주로 테스트용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "날씨 정보 생성 및 저장 성공",
+                         content = { @Content(mediaType = "application/json",
+                         schema = @Schema(implementation = WeatherResponseDto.class)) }),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류 발생", content = @Content)
+    })
     @PostMapping("/today/generate-manual") // 경로를 명확히 구분
     public ResponseEntity<?> generateTodaysWeatherManually() {
         try {
@@ -41,6 +58,13 @@ public class WeatherController {
         }
     }
 
+    @Operation(summary = "최신 채용 날씨 정보 조회", description = "DB에 저장된 가장 최근 날짜의 채용 날씨 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = { @Content(mediaType = "application/json",
+                         schema = @Schema(implementation = WeatherResponseDto.class)) }),
+            @ApiResponse(responseCode = "404", description = "데이터 없음", content = @Content)
+    })
     @GetMapping("/latest")
     public ResponseEntity<WeatherResponseDto> getLatestWeather() {
         Optional<WeatherResponseDto> weatherOpt = weatherService.getLatestWeatherReport();
@@ -48,6 +72,13 @@ public class WeatherController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
+    @Operation(summary = "특정 날짜 채용 날씨 정보 조회", description = "URL 경로의 {date}에 해당하는 날짜의 채용 날씨 정보를 DB에서 조회하여 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                         content = { @Content(mediaType = "application/json",
+                         schema = @Schema(implementation = WeatherResponseDto.class)) }),
+            @ApiResponse(responseCode = "404", description = "해당 날짜 데이터 없음", content = @Content)
+    })
     @GetMapping("/{date}")
     public ResponseEntity<WeatherResponseDto> getWeatherByDate(
             @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {


### PR DESCRIPTION
## 🚀 작업한 기능 설명 (Feature Description)
- Swagger(OpenAPI 3) 어노테이션 추가하여 API 명세 문서를 작업했습니다.

## 🔍 작업 상세 (Implementation Details)
- 각 컨트롤러 클래스 및 핸들러 메소드에 `@Tag`, `@Operation`, `@Parameter`, `@ApiResponses`, `@ApiResponse` 등의 Swagger 어노테이션을 추가하여 API의 기능, 파라미터, 응답 형식 등을 명확히 기술했습니다.
- 요청 및 응답에 사용되는 주요 DTO 클래스 (`SignUpDto`, `LogInDto`, `NewsDto`, `ProfileDTO`, `CustomDTO`, `NotificationDto`, `WeatherResponseDto`, `MainPageRecommendationsDto` 등)에 `@Schema` 어노테이션을 추가하여 데이터 모델을 설명했습니다.
- `HttpSession`과 같이 클라이언트가 직접 전달하지 않는 파라미터는 `@Parameter(hidden = true)`로 설정하여 Swagger UI에서 숨김 처리했습니다.
- API 응답 예시(`example`)를 추가하여 개발자들이 응답 형식을 더 쉽게 이해할 수 있도록 했습니다.
- 일부 컨트롤러에서 로깅을 추가하고, 반환 타입을 `ResponseEntity`로 통일하여 API 응답의 일관성을 높였습니다.
- Java에서 import 시 별칭(alias)을 사용할 수 없는 문법 오류를 수정했습니다 (예: Swagger의 `RequestBody` 어노테이션 사용 시 정규화된 이름 사용).
- `NewsController`의 `getNews` API 응답 형식을 기존 `Map` 반환 방식에 맞게 Swagger 명세를 수정했습니다.

## 📝 추가 정보 (Additional Information)
- localhost:8080/swagger-ui/index.html
- 백엔드 서버에서 위 URL로 API 문서에 접근할 수 있습니다.